### PR TITLE
perf: prefer defer instead async

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -21,7 +21,7 @@
             "\t\t\t<p class=\"browsehappy\">You are using an <strong>outdated</strong> browser. Please <a href=\"#\">upgrade your browser</a> to improve your experience.</p>",
 			"\t\t<![endif]-->",
 			"\t\t$3",
-			"\t\t<script src=\"$4\" async defer></script>",
+			"\t\t<script src=\"$4\" defer></script>",
 			"\t</body>",
 			"</html>"
 		],


### PR DESCRIPTION
as stated by Harry Roberts in https://twitter.com/csswizardry/status/1331721659498319873 the combination of "async defer" nowadays will never lead to the faster "defer".

Is this ok?

# ✨ Pull Request

### PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)
  - no docs regarding "async defer" - no changes needed 

### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg,  Fixes: #&lt;issue-number&gt; -->

### ℹ️ About the PR

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### 🖼️ Testing Scenarios / Screenshots

testing about "async defer" described in detail here: https://almanac.httparchive.org/en/2020/javascript#how-do-we-load-our-javascript. 

> Considering that defer provides us with the best loading performance (by ensuring downloading the script happens in parallel to other work, and execution waits until after the page can be displayed), we would hope to see that percentage a bit higher. In fact, as it is that 6.0% is slightly inflated.
>
>Back when supporting IE8 and IE9 was more common, it was relatively common to use both the async and defer attributes. With both attributes in place, any browser supporting both will use async. IE8 and IE9, which don’t support async will fall back to defer.
>
>Nowadays, the pattern is unnecessary for the vast majority of sites and any script loaded with the pattern in place will interrupt the HTML parser when it needs to be executed, instead of deferring until the page has loaded. The pattern is still used surprisingly often, with 11.4% of mobile pages serving at least one script with that pattern in place. In other words, at least some of the 6% of scripts that use defer aren’t getting the full benefits of the defer attribute.

As this PR edits "just" a small boilerplate, I've not done extra testing. The linked article has been broadcasted by [_smashing magazine_](https://mailchi.mp/smashingmagazine/smashing-newsletter-285-javascript-edition?e=dec702f74e), so I guess this counts as some sort of peer review ^^
