### PR TITLE
Remove extra html comment start

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -6,7 +6,7 @@
 			"<!--[if lt IE 7]>      <html class=\"no-js lt-ie9 lt-ie8 lt-ie7\"> <![endif]-->",
 			"<!--[if IE 7]>         <html class=\"no-js lt-ie9 lt-ie8\"> <![endif]-->",
 			"<!--[if IE 8]>         <html class=\"no-js lt-ie9\"> <![endif]-->",
-			"<!--[if gt IE 8]>      <html class=\"no-js\"> <!--<![endif]-->",
+			"<!--[if gt IE 8]>      <html class=\"no-js\"> <![endif]-->",
 			"<html>",
 			"\t<head>",
 			"\t\t<meta charset=\"utf-8\">",


### PR DESCRIPTION
vs code highlighted the change as an error. I assume it was a typo.
Please let me know if there is some purpose I am unaware of.